### PR TITLE
Fill news table + load all sources into UI

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,13 @@
 import { Stack } from "expo-router";
 
 export default function RootLayout() {
-  return <Stack />;
+  return (
+    <Stack>
+      <Stack.Screen name="index" options={{ title: "Canary.ai" }} />
+      <Stack.Screen
+        name="source/[sourceId]"
+        options={{ title: "Source Feed" }}
+      />
+    </Stack>
+  );
 }

--- a/app/source/[sourceId].tsx
+++ b/app/source/[sourceId].tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useLocalSearchParams } from "expo-router";
 import {
   ActivityIndicator,
   ScrollView,
@@ -7,12 +8,19 @@ import {
   View,
 } from "react-native";
 
-import { SourceOverviewCard } from "@/components/SourceOverviewCard";
-import { fetchOverview } from "@/lib/api";
-import type { OverviewSource } from "@/lib/types";
+import { FeedEntryCard } from "@/components/FeedEntryCard";
+import { fetchSourceFeed, resolveSourceId } from "@/lib/api";
+import type { FeedItem } from "@/lib/types";
 
-export default function LandingPage() {
-  const [sources, setSources] = useState<OverviewSource[]>([]);
+export default function SourcePage() {
+  const params = useLocalSearchParams<{ sourceId?: string }>();
+  const safeSourceId = useMemo(
+    () => resolveSourceId(params.sourceId || ""),
+    [params.sourceId],
+  );
+
+  const [title, setTitle] = useState("Source Feed");
+  const [items, setItems] = useState<FeedItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -22,14 +30,15 @@ export default function LandingPage() {
     async function load() {
       try {
         setLoading(true);
-        const data = await fetchOverview();
+        const data = await fetchSourceFeed(safeSourceId);
         if (mounted) {
-          setSources(data.sources);
+          setTitle(`${data.name} Feed`);
+          setItems(data.items);
           setError(null);
         }
       } catch {
         if (mounted) {
-          setError("Could not load data. Is backend running on port 3001?");
+          setError("Could not load source feed.");
         }
       } finally {
         if (mounted) {
@@ -43,14 +52,13 @@ export default function LandingPage() {
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [safeSourceId]);
 
   return (
     <ScrollView contentContainerStyle={styles.container}>
-      <Text style={styles.pageTitle}>Canary Feed Overview</Text>
-
+      <Text style={styles.pageTitle}>{title}</Text>
       <Text style={styles.pageSubtitle}>
-        Source previews for weather channels, news, and social media.
+        Top five entries currently in the database.
       </Text>
 
       {loading ? <ActivityIndicator size="large" /> : null}
@@ -58,8 +66,8 @@ export default function LandingPage() {
 
       {!loading && !error ? (
         <View style={styles.list}>
-          {sources.map((source) => (
-            <SourceOverviewCard key={source.id} source={source} />
+          {items.map((item) => (
+            <FeedEntryCard key={item.id} item={item} sourceId={safeSourceId} />
           ))}
         </View>
       ) : null}

--- a/backend/index.js
+++ b/backend/index.js
@@ -54,7 +54,7 @@ async function fetchTopSocial(limit = 5) {
     ...tweets.map((row) => ({
       kind: "tweet",
       id: `tweet-${row.tweet_id}`,
-      author: row.author_id || row.author || "social post",
+      author: row.author || row.author_id || "social post",
       body: row.summary || row.raw_text || "",
       subtitle: row.location || "X",
       url: row.url || null,

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,1 +1,302 @@
-console.log("Hello via Bun!");
+require("dotenv/config");
+const express = require("express");
+const cors = require("cors");
+const { PrismaClient } = require("@prisma/client");
+
+const app = express();
+const prisma = new PrismaClient();
+
+app.use(cors());
+app.use(express.json());
+
+const PORT = Number(process.env.PORT || 3001);
+
+function excerpt(text, max = 160) {
+  if (!text) return "No preview available.";
+  if (text.length <= max) return text;
+  return `${text.slice(0, max).trim()}...`;
+}
+
+function normalizeSourceId(sourceId) {
+  if (sourceId === "weather-channels") return "weather";
+  if (sourceId === "social-media") return "social";
+  return sourceId;
+}
+
+async function safeFetch(fetcher, label) {
+  try {
+    return await fetcher();
+  } catch (error) {
+    console.error(`Failed to fetch ${label}:`, error);
+    return [];
+  }
+}
+
+async function fetchTopNews(limit = 5) {
+  return prisma.newsArticle.findMany({
+    take: limit,
+    orderBy: [{ publishedAt: "desc" }, { importedAt: "desc" }],
+  });
+}
+
+async function fetchTopSocial(limit = 5) {
+  const tweets = await prisma.tweet.findMany({
+    take: limit,
+    orderBy: [{ created_at: "desc" }],
+  });
+
+  const bluesky = await prisma.bluesky.findMany({
+    take: limit,
+    orderBy: [{ created_at: "desc" }],
+  });
+
+  const combined = [
+    ...tweets.map((row) => ({
+      kind: "tweet",
+      id: `tweet-${row.tweet_id}`,
+      author: row.author_id || row.author || "social post",
+      body: row.summary || row.raw_text || "",
+      subtitle: row.location || "X",
+      url: row.url || null,
+      timestamp: row.created_at || null,
+    })),
+    ...bluesky.map((row) => ({
+      kind: "bluesky",
+      id: `bluesky-${row.post_cid}`,
+      author: row.author_id || row.author || "social post",
+      body: row.summary || row.raw_text || "",
+      subtitle: "Bluesky",
+      url: row.url || null,
+      timestamp: row.created_at || null,
+    })),
+  ];
+
+  combined.sort((a, b) => {
+    const aTime = a.timestamp ? new Date(a.timestamp).getTime() : 0;
+    const bTime = b.timestamp ? new Date(b.timestamp).getTime() : 0;
+    return bTime - aTime;
+  });
+
+  return combined.slice(0, limit);
+}
+
+async function fetchTopWeather(limit = 5) {
+  return prisma.weatherAlert.findMany({
+    take: limit,
+    orderBy: [{ issued_at: "desc" }],
+  });
+}
+
+function mapNews(items) {
+  return items.map((item) => ({
+    id: String(item.id),
+    title: item.title || "Untitled",
+    body: excerpt(item.summary || item.description),
+    subtitle: item.publisher || "Unknown publisher",
+    url: item.url || null,
+    timestamp: item.publishedAt || item.importedAt || null,
+  }));
+}
+
+function mapSocial(items) {
+  return items.map((item) => ({
+    id: String(item.id),
+    title: item.author ? `@${item.author}` : "Social post",
+    body: excerpt(item.body),
+    subtitle: item.subtitle || "Social",
+    url: item.url || null,
+    timestamp: item.timestamp || null,
+  }));
+}
+
+function mapWeather(items) {
+  return items.map((item, idx) => ({
+    id: String(item.id || idx),
+    title: item.event_name || `${item.wfo || "NWS"} ${item.pil || "Alert"}`,
+    body: excerpt(item.raw_text),
+    subtitle:
+      item.wfo && item.pil ? `${item.wfo} / ${item.pil}` : "Weather feed",
+    url: null,
+    timestamp: item.issued_at || null,
+  }));
+}
+
+async function fetchItemFullBody(sourceId, itemId) {
+  if (sourceId === "news") {
+    const numericId = Number(itemId);
+    if (!Number.isInteger(numericId)) return null;
+
+    const row = await prisma.newsArticle.findUnique({
+      where: { id: numericId },
+      select: { id: true, summary: true, description: true },
+    });
+    if (!row) return null;
+
+    return {
+      id: String(row.id),
+      fullBody: row.summary || row.description || "No preview available.",
+    };
+  }
+
+  if (sourceId === "weather") {
+    const row = await prisma.weatherAlert.findUnique({
+      where: { id: itemId },
+      select: { id: true, raw_text: true },
+    });
+    if (!row) return null;
+
+    return {
+      id: String(row.id),
+      fullBody: row.raw_text || "No preview available.",
+    };
+  }
+
+  if (sourceId === "social") {
+    if (itemId.startsWith("tweet-")) {
+      const rawId = itemId.slice("tweet-".length);
+      if (!rawId) return null;
+
+      const row = await prisma.tweet.findUnique({
+        where: { tweet_id: BigInt(rawId) },
+        select: { tweet_id: true, summary: true, raw_text: true },
+      });
+      if (!row) return null;
+
+      return {
+        id: `tweet-${row.tweet_id.toString()}`,
+        fullBody: row.summary || row.raw_text || "No preview available.",
+      };
+    }
+
+    if (itemId.startsWith("bluesky-")) {
+      const postCid = itemId.slice("bluesky-".length);
+      if (!postCid) return null;
+
+      const row = await prisma.bluesky.findUnique({
+        where: { post_cid: postCid },
+        select: { post_cid: true, summary: true, raw_text: true },
+      });
+      if (!row) return null;
+
+      return {
+        id: `bluesky-${row.post_cid}`,
+        fullBody: row.summary || row.raw_text || "No preview available.",
+      };
+    }
+  }
+
+  return null;
+}
+
+app.get("/health", (_req, res) => {
+  res.json({ ok: true });
+});
+
+app.get("/api/overview", async (_req, res) => {
+  try {
+    const [weatherRows, newsRows, socialRows] = await Promise.all([
+      safeFetch(() => fetchTopWeather(5), "weather rows"),
+      safeFetch(() => fetchTopNews(5), "news rows"),
+      safeFetch(() => fetchTopSocial(5), "social rows"),
+    ]);
+
+    const weatherItems = mapWeather(weatherRows);
+    const newsItems = mapNews(newsRows);
+    const socialItems = mapSocial(socialRows);
+
+    res.json({
+      sources: [
+        {
+          id: "weather",
+          name: "Weather Channels",
+          totalCount: weatherItems.length,
+          preview: weatherItems.slice(0, 2),
+        },
+        {
+          id: "news",
+          name: "News",
+          totalCount: newsItems.length,
+          preview: newsItems.slice(0, 2),
+        },
+        {
+          id: "social",
+          name: "Social Media",
+          totalCount: socialItems.length,
+          preview: socialItems.slice(0, 2),
+        },
+      ],
+    });
+  } catch (error) {
+    console.error("Failed /api/overview:", error);
+    res.status(500).json({ error: "Unable to load overview data." });
+  }
+});
+
+app.get("/api/sources/:sourceId", async (req, res) => {
+  const sourceId = normalizeSourceId(req.params.sourceId);
+
+  try {
+    if (sourceId === "weather") {
+      const weatherRows = await safeFetch(
+        () => fetchTopWeather(5),
+        "weather rows",
+      );
+      return res.json({
+        id: "weather",
+        name: "Weather Channels",
+        items: mapWeather(weatherRows),
+      });
+    }
+
+    if (sourceId === "news") {
+      const newsRows = await safeFetch(() => fetchTopNews(5), "news rows");
+      return res.json({
+        id: "news",
+        name: "News",
+        items: mapNews(newsRows),
+      });
+    }
+
+    if (sourceId === "social") {
+      const socialRows = await safeFetch(
+        () => fetchTopSocial(5),
+        "social rows",
+      );
+      return res.json({
+        id: "social",
+        name: "Social Media",
+        items: mapSocial(socialRows),
+      });
+    }
+
+    return res.status(404).json({ error: "Unknown source." });
+  } catch (error) {
+    console.error("Failed /api/sources:", error);
+    return res.status(500).json({ error: "Unable to load source feed." });
+  }
+});
+
+app.get("/api/sources/:sourceId/:itemId", async (req, res) => {
+  const sourceId = normalizeSourceId(req.params.sourceId);
+  const itemId = decodeURIComponent(req.params.itemId || "");
+
+  if (!itemId) {
+    return res.status(400).json({ error: "Missing item id." });
+  }
+
+  try {
+    const item = await fetchItemFullBody(sourceId, itemId);
+    if (!item) {
+      return res.status(404).json({ error: "Item not found." });
+    }
+
+    return res.json(item);
+  } catch (error) {
+    console.error("Failed /api/sources/:sourceId/:itemId:", error);
+    return res.status(500).json({ error: "Unable to load full item content." });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Canary backend API listening on http://localhost:${PORT}`);
+});

--- a/backend/index.js
+++ b/backend/index.js
@@ -63,7 +63,7 @@ async function fetchTopSocial(limit = 5) {
     ...bluesky.map((row) => ({
       kind: "bluesky",
       id: `bluesky-${row.post_cid}`,
-      author: row.author_id || row.author || "social post",
+      author: row.author || row.author_id || "social post",
       body: row.summary || row.raw_text || "",
       subtitle: "Bluesky",
       url: row.url || null,

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,12 +10,17 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.19.2",
+        "@supabase/supabase-js": "^2.98.0",
         "cors": "^2.8.6",
         "express": "^5.2.1"
       },
       "devDependencies": {
+        "@types/bun": "latest",
         "dotenv": "^17.3.1",
         "prisma": "^6.19.2"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
       }
     },
     "node_modules/@prisma/client": {
@@ -110,6 +115,110 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.99.1.tgz",
+      "integrity": "sha512-x7lKKTvKjABJt/FYcRSPiTT01Xhm2FF8RhfL8+RHMkmlwmRQ88/lREupIHKwFPW0W6pTCJqkZb7Yhpw/EZ+fNw==",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.99.1.tgz",
+      "integrity": "sha512-WQE62W5geYImCO4jzFxCk/avnK7JmOdtqu2eiPz3zOaNiIJajNRSAwMMDgEGd2EMs+sUVYj1LfBjfmW3EzHgIA==",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.99.1.tgz",
+      "integrity": "sha512-gtw2ibJrADvfqrpUWXGNlrYUvxttF4WVWfPpTFKOb2IRj7B6YRWMDgcrYqIuD4ZEabK4m6YKQCCGy6clgf1lPA==",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.99.1.tgz",
+      "integrity": "sha512-9EDdy/5wOseGFqxW88ShV9JMRhm7f+9JGY5x+LqT8c7R0X1CTLwg5qie8FiBWcXTZ+68yYxVWunI+7W4FhkWOg==",
+      "dependencies": {
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.99.1.tgz",
+      "integrity": "sha512-mf7zPfqofI62SOoyQJeNUVxe72E4rQsbWim6lTDPeLu3lHija/cP5utlQADGrjeTgOUN6znx/rWn7SjrETP1dw==",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.99.1.tgz",
+      "integrity": "sha512-5MRoYD9ffXq8F6a036dm65YoSHisC3by/d22mauKE99Vrwf792KxYIIr/iqCX7E4hkuugbPZ5EGYHTB7MKy6Vg==",
+      "dependencies": {
+        "@supabase/auth-js": "2.99.1",
+        "@supabase/functions-js": "2.99.1",
+        "@supabase/postgrest-js": "2.99.1",
+        "@supabase/realtime-js": "2.99.1",
+        "@supabase/storage-js": "2.99.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@types/bun": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.10.tgz",
+      "integrity": "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ==",
+      "dev": true,
+      "dependencies": {
+        "bun-types": "1.3.10"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.4.0.tgz",
+      "integrity": "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw==",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q=="
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -145,6 +254,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bun-types": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.10.tgz",
+      "integrity": "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/bytes": {
@@ -717,6 +835,14 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -1253,6 +1379,11 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -1266,6 +1397,24 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -1290,6 +1439,26 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,10 @@
     "test": "test"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "import-news": "npx tsx import-news-articles.ts",
+    "import-final-results": "node import-final-results.js",
+    "start": "node index.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,19 +1,63 @@
-
 generator client {
   provider = "prisma-client-js"
 }
 
 datasource db {
-  provider  = "postgresql"
-  url = env("DATABASE_URL")
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model Bluesky {
+  author     String?
+  author_id  String?
+  raw_text   String?
+  raw_json   Json?     @db.Json
+  url        String?
+  created_at DateTime? @db.Timestamptz(6)
+  summary    String?
+  post_cid   String    @id @unique
+
+  @@map("bluesky")
+}
+
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
 model Tweet {
+  tweet_id        BigInt   @id @unique @default(autoincrement())
+  author          String?
+  location        String?
+  summary         String?
+  raw_text        String?
+  raw_json        Json?    @db.Json
+  url             String?
+  created_at      DateTime @default(now()) @db.Timestamptz(6)
+  relevancy_label Boolean? @default(false)
+  author_id       String?
+
+  @@map("tweets")
+}
+
+/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model WeatherAlert {
+  id         String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  wfo        String
+  pil        String
+  raw_text   String
+  summary    String?
+  issued_at  DateTime? @db.Timestamptz(6)
+  event_name String?
+
+  @@map("weather_alerts")
+}
+
+model NewsArticle {
   id          Int      @id @default(autoincrement())
-  tweetId     String   @unique
-  text        String?
-  authorId    String?
-  createdAt   DateTime?
-  raw         Json?
+  title       String
+  url         String   @unique
+  publisher   String?
+  publishedAt DateTime?
+  summary     String?
+  description String?
   importedAt  DateTime @default(now())
 }

--- a/components/FeedEntryCard.tsx
+++ b/components/FeedEntryCard.tsx
@@ -1,0 +1,172 @@
+import { Ionicons } from "@expo/vector-icons";
+import * as Linking from "expo-linking";
+import { useState } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import { fetchSourceItemDetail } from "@/lib/api";
+import type { FeedItem, SourceId } from "@/lib/types";
+
+type Props = {
+  item: FeedItem;
+  sourceId: SourceId;
+};
+
+export function FeedEntryCard({ item, sourceId }: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const [fullBody, setFullBody] = useState<string | null>(null);
+  const [loadingFullBody, setLoadingFullBody] = useState(false);
+  const [fullBodyError, setFullBodyError] = useState<string | null>(null);
+
+  const displayBody = expanded ? fullBody || item.body : item.body;
+
+  async function openSource() {
+    if (!item.url) return;
+    await Linking.openURL(item.url);
+  }
+
+  async function toggleExpanded() {
+    if (expanded) {
+      setExpanded(false);
+      return;
+    }
+
+    setExpanded(true);
+
+    if (fullBody || loadingFullBody) {
+      return;
+    }
+
+    try {
+      setLoadingFullBody(true);
+      setFullBodyError(null);
+      const detail = await fetchSourceItemDetail(sourceId, item.id);
+      setFullBody(detail.fullBody);
+    } catch {
+      setFullBodyError("Could not load full text.");
+    } finally {
+      setLoadingFullBody(false);
+    }
+  }
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.textBlock}>
+        <Text style={styles.title}>{item.title}</Text>
+        <Text numberOfLines={expanded ? undefined : 4} style={styles.body}>
+          {displayBody}
+        </Text>
+        {expanded && loadingFullBody ? (
+          <Text style={styles.metaText}>Loading full text...</Text>
+        ) : null}
+        {expanded && fullBodyError ? (
+          <Text style={styles.errorText}>{fullBodyError}</Text>
+        ) : null}
+      </View>
+
+      <View style={styles.buttonGroup}>
+        <Pressable
+          onPress={toggleExpanded}
+          style={({ pressed }) => [
+            styles.actionButton,
+            pressed && styles.pressed,
+          ]}
+        >
+          <Text style={styles.actionText}>
+            {expanded ? "See less" : "See all"}
+          </Text>
+        </Pressable>
+
+        <View style={styles.badge}>
+          <Text style={styles.badgeText}>{item.subtitle}</Text>
+        </View>
+
+        {item.url ? (
+          <Pressable
+            accessibilityLabel="Open source link"
+            onPress={openSource}
+            style={({ pressed }) => [
+              styles.iconButton,
+              pressed && styles.pressed,
+            ]}
+          >
+            <Ionicons name="open-outline" size={18} color="#1E1E1E" />
+          </Pressable>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+    borderColor: "#E0E0E0",
+    borderRadius: 12,
+    backgroundColor: "#FFFFFF",
+    padding: 16,
+    gap: 16,
+  },
+  textBlock: {
+    gap: 8,
+  },
+  title: {
+    color: "#1E1E1E",
+    fontSize: 18,
+    fontWeight: "600",
+  },
+  body: {
+    color: "#757575",
+    lineHeight: 20,
+    fontSize: 14,
+  },
+  metaText: {
+    color: "#757575",
+    fontSize: 12,
+  },
+  errorText: {
+    color: "#B3261E",
+    fontSize: 12,
+  },
+  buttonGroup: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  actionButton: {
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#767676",
+    backgroundColor: "#E3E3E3",
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+  },
+  actionText: {
+    color: "#1E1E1E",
+    fontWeight: "500",
+  },
+  badge: {
+    borderWidth: 1,
+    borderColor: "#E0E0E0",
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 10,
+    flexShrink: 1,
+  },
+  badgeText: {
+    color: "#1E1E1E",
+    fontSize: 12,
+  },
+  iconButton: {
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#767676",
+    backgroundColor: "#FFFFFF",
+    width: 38,
+    height: 38,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  pressed: {
+    opacity: 0.85,
+  },
+});

--- a/components/SourceOverviewCard.tsx
+++ b/components/SourceOverviewCard.tsx
@@ -1,0 +1,96 @@
+import { router } from "expo-router";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import type { OverviewSource } from "@/lib/types";
+
+type Props = {
+  source: OverviewSource;
+};
+
+export function SourceOverviewCard({ source }: Props) {
+  const previewText =
+    source.preview.length > 0
+      ? source.preview.map((entry) => entry.title).join("\n")
+      : "No entries found yet.";
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.textBlock}>
+        <Text style={styles.title}>{source.name}</Text>
+        <Text numberOfLines={3} style={styles.body}>
+          {previewText}
+        </Text>
+      </View>
+
+      <View style={styles.buttonGroup}>
+        <Pressable
+          onPress={() => router.push(`/source/${source.id}`)}
+          style={({ pressed }) => [
+            styles.secondaryButton,
+            pressed && styles.pressed,
+          ]}
+        >
+          <Text style={styles.secondaryButtonText}>See all</Text>
+        </Pressable>
+
+        <View style={styles.countBadge}>
+          <Text style={styles.countText}>Top {source.totalCount}</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+    borderColor: "#E0E0E0",
+    borderRadius: 12,
+    padding: 16,
+    backgroundColor: "#FFFFFF",
+    gap: 16,
+  },
+  textBlock: {
+    gap: 8,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: "600",
+    color: "#1E1E1E",
+  },
+  body: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: "#757575",
+  },
+  buttonGroup: {
+    flexDirection: "row",
+    gap: 12,
+    alignItems: "center",
+  },
+  secondaryButton: {
+    borderWidth: 1,
+    borderColor: "#767676",
+    backgroundColor: "#E3E3E3",
+    borderRadius: 8,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+  },
+  secondaryButtonText: {
+    color: "#1E1E1E",
+    fontWeight: "500",
+  },
+  countBadge: {
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#E0E0E0",
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  countText: {
+    color: "#1E1E1E",
+  },
+  pressed: {
+    opacity: 0.8,
+  },
+});

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,58 @@
+import Constants from "expo-constants";
+
+import type {
+  OverviewResponse,
+  SourceFeedResponse,
+  SourceId,
+  SourceItemDetailResponse,
+} from "@/lib/types";
+
+const maybeHostUri =
+  Constants.expoConfig?.hostUri ||
+  (Constants as unknown as { expoGoConfig?: { debuggerHost?: string } })
+    .expoGoConfig?.debuggerHost;
+const host = maybeHostUri ? maybeHostUri.split(":")[0] : "localhost";
+const fallbackBaseUrl = `http://${host}:3001/api`;
+
+const rawBaseUrl =
+  process.env.EXPO_PUBLIC_API_BASE_URL?.trim() || fallbackBaseUrl;
+const normalizedBaseUrl = rawBaseUrl.replace(/\/+$/, "");
+const API_BASE_URL = normalizedBaseUrl.endsWith("/api")
+  ? normalizedBaseUrl
+  : `${normalizedBaseUrl}/api`;
+
+async function request<T>(path: string): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`);
+
+  if (!response.ok) {
+    throw new Error(`Request failed (${response.status}) for ${path}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+export function fetchOverview(): Promise<OverviewResponse> {
+  return request<OverviewResponse>("/overview");
+}
+
+export function fetchSourceFeed(
+  sourceId: SourceId,
+): Promise<SourceFeedResponse> {
+  return request<SourceFeedResponse>(`/sources/${sourceId}`);
+}
+
+export function fetchSourceItemDetail(
+  sourceId: SourceId,
+  itemId: string,
+): Promise<SourceItemDetailResponse> {
+  return request<SourceItemDetailResponse>(
+    `/sources/${sourceId}/${encodeURIComponent(itemId)}`,
+  );
+}
+
+export function resolveSourceId(sourceId: string): SourceId {
+  if (sourceId === "weather" || sourceId === "news" || sourceId === "social") {
+    return sourceId;
+  }
+  return "news";
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,32 @@
+export type SourceId = "weather" | "news" | "social";
+
+export type FeedItem = {
+  id: string;
+  title: string;
+  body: string;
+  subtitle: string;
+  url: string | null;
+  timestamp: string | null;
+};
+
+export type OverviewSource = {
+  id: SourceId;
+  name: string;
+  totalCount: number;
+  preview: FeedItem[];
+};
+
+export type OverviewResponse = {
+  sources: OverviewSource[];
+};
+
+export type SourceFeedResponse = {
+  id: SourceId;
+  name: string;
+  items: FeedItem[];
+};
+
+export type SourceItemDetailResponse = {
+  id: string;
+  fullBody: string;
+};


### PR DESCRIPTION
Made some big changes to get to more of an MVP state.
1. Made the prisma schema more consistent (PascalCase and non-plural for the model, and then linked them to the snake_case table names in Supabase)
2. Added NewsArticle and populated that DB.
2. Added a front end. This is pretty basic, but per our Figma the home page has three cards per type of data source, and some preview of the title names. 
- If you click in you'll see a feed of the top 5 entries, and you can either expand all or go to the source itself.

The shown summary might need changes to be more expressive, especially for weather alerts. The text body of the weather alerts might need some cleaning. We'll need to implement a ranking system to choose which ones we'd like to show, since right now it's just five off the top of the table. After that we might be at MVP. 